### PR TITLE
Fix missing add apt repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get -y install \
 	g++ \ 
 	curl \
 	lua5.2 \
-	liblua5.2-dev
+	liblua5.2-dev \
+    software-properties-common
 RUN pip install numpy scipy
 
 # torch installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-char-nn
+# docker-char-rnn
 Docker container for use with Multi-layer Recurrent Neural Networks (LSTM, GRU, RNN) for character-level language models in Torch
 
 ## Usage


### PR DESCRIPTION
I'm not sure if the Ubuntu image changed or the Torch install changed, but I keep getting `add-apt-repository: command not found` when trying to build the Docker image. This package provides that command.